### PR TITLE
Update Sample .NET

### DIFF
--- a/jaas-jwt-samples/net/Program.cs
+++ b/jaas-jwt-samples/net/Program.cs
@@ -209,7 +209,7 @@ namespace jaas_jwt
             /// </returns>
             public JaaSJwtBuilder WithNbfTime(DateTime nbfTime)
             {
-                payload.Add("nbf", new DateTimeOffset(nbfTime).ToUnixTimeSeconds());
+                payload.Add("nbfTime", new DateTimeOffset(nbfTime).ToUnixTimeSeconds());
                 return this;
             }
 


### PR DESCRIPTION
There is a missing tag that changed and got me 3 days of debuggin to find out it was an error on the sample code. 

Side note: I use .NET Framework 4.6.1 and this sample only works in .NET Core 3 or above. So I had to change my sample to work propertly. I will share my code in this description and sugges to the team to publish this sample as optional for who is implementing it on .NET Framework:

 ```
private static RSA RsaKeyAsPerContent()
        {
            RSA rSA = RSA.Create();

            string privateKeyFromConfig = ConfigurationManager.AppSettings["JAAS-PrivateKey"];
            privateKeyFromConfig = privateKeyFromConfig.Replace(BEGIN_RSA_PRIVATE_KEY, "");
            privateKeyFromConfig = privateKeyFromConfig.Replace(END_RSA_PRIVATE_KEY, "");
            rSA.ImportParameters(ImportPrivateKey(privateKeyFromConfig));
            return rSA;
        }

        public static RSAParameters ImportPrivateKey(string pem)
        {
            
            Merged::Org.BouncyCastle.OpenSsl.PemReader pr = new Merged::Org.BouncyCastle.OpenSsl.PemReader(new StringReader(pem));
            Merged::Org.BouncyCastle.Crypto.Parameters.RsaPrivateCrtKeyParameters privKey = (Merged::Org.BouncyCastle.Crypto.Parameters.RsaPrivateCrtKeyParameters)pr.ReadObject();
            RSAParameters rp = Merged::Org.BouncyCastle.Security.DotNetUtilities.ToRSAParameters(privKey); //new RSAParameters();
            //rp.Modulus = privKey.Modulus.ToByteArrayUnsigned();
            //rp.Exponent = privKey.PublicExponent.ToByteArrayUnsigned();
            //rp.P = privKey.P.ToByteArrayUnsigned();
            //rp.Q = privKey.Q.ToByteArrayUnsigned();
            //rp.D = ConvertRSAParametersField(privKey.Exponent, rp.Modulus.Length);
            //rp.DP = ConvertRSAParametersField(privKey.DP, rp.P.Length);
            //rp.DQ = ConvertRSAParametersField(privKey.DQ, rp.Q.Length);
            //rp.InverseQ = ConvertRSAParametersField(privKey.QInv, rp.Q.Length);


            return rp;
        }

        private static byte[] ConvertRSAParametersField(Merged::Org.BouncyCastle.Math.BigInteger n, int size)
        {
            byte[] bs = n.ToByteArrayUnsigned();
            if (bs.Length == size)
                return bs;
            if (bs.Length > size)
                throw new ArgumentException("Specified size too small", "size");
            byte[] padded = new byte[size];
            Array.Copy(bs, 0, padded, size - bs.Length, bs.Length);
            return padded;
        }
```